### PR TITLE
Renames V1SCHEMA to SCHEMA

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -84,7 +84,7 @@ cp -R $CACHE_DIR/$BIN $BUILD_DIR
 echo "-----> Creating Procfile"
 if legacyMode; then
   cat <<EOF > $BUILD_DIR/Procfile
-web: ./${BIN} -p \$PORT -s -d \$DB_NAME -U \$AUTH_ROLE --db-pass \$AUTH_PASS -a \$ANONYMOUS_ROLE --db-host \$DB_HOST -P \$DB_PORT --db-pool \$DB_POOL --jwt-secret \$JWT_SECRET --v1schema \$V1SCHEMA
+web: ./${BIN} -p \$PORT -s -d \$DB_NAME -U \$AUTH_ROLE --db-pass \$AUTH_PASS -a \$ANONYMOUS_ROLE --db-host \$DB_HOST -P \$DB_PORT --db-pool \$DB_POOL --jwt-secret \$JWT_SECRET --v1schema \$SCHEMA
 EOF
 else
   cat <<EOF > $BUILD_DIR/Procfile


### PR DESCRIPTION
So both legacy and current start commands are consistent with the new parameter semantic
