### PR TITLE
Default to 0.4.4.0 instead of 0.4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and run these commands.
 heroku apps:create --buildpack https://github.com/begriffs/postgrest-heroku.git
 
 # now fill in the values specific to your database
-heroku config:set POSTGREST_VER=0.4.0.0
+heroku config:set POSTGREST_VER=0.4.4.0
 heroku config:set DB_URI=postgres://postgrest_test:postgrest111@postgrest-test.crbxuv1p3j1c.us-west-1.rds.amazonaws.com/postgrest_test
 heroku config:set DB_SCHEMA=public
 heroku config:set DB_ANON_ROLE=postgrest_test

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ CACHE_DIR="$2"
 ENV_DIR="$3"
 BP_DIR=`cd $(dirname $0); cd ..; pwd`
 
-POSTGREST_VER=${POSTGREST_VER:-0.4.0.0}
+POSTGREST_VER=${POSTGREST_VER:-0.4.4.0}
 CLEAR_CACHE=${CLEAR_CACHE:-0}
 
 ver20() {


### PR DESCRIPTION
If the POSTGREST_VER config is missing on Heroku, the deployment will now use version 0.4.4.0 instead of 0.4.0.0