### PR TITLE
Always cache binary with version to allow env updates

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,11 +68,7 @@ fi
 
 ############# PostgREST binary ################################
 
-if ver20; then
-  BIN="postgrest-${POSTGREST_VER}"
-else
-  BIN="postgrest"
-fi
+BIN="postgrest-${POSTGREST_VER}"
 
 if ver20 || ver30 || ver40to42; then
   RELEASE_VER="${POSTGREST_VER}"

--- a/bin/compile
+++ b/bin/compile
@@ -82,6 +82,7 @@ if [ ! -e $CACHE_DIR/$BIN ]; then
     echo "-----> Downloading and caching PostgREST $POSTGREST_VER binary"
     mkdir -p $CACHE_DIR
     curl -# -L $BIN_URL | tar xJ -C $CACHE_DIR
+    mv $CACHE_DIR/postgrest $CACHE_DIR/$BIN
   else
     echo "-----> Could not find prebuilt $BIN"
     exit 1

--- a/bin/compile
+++ b/bin/compile
@@ -82,7 +82,9 @@ if [ ! -e $CACHE_DIR/$BIN ]; then
     echo "-----> Downloading and caching PostgREST $POSTGREST_VER binary"
     mkdir -p $CACHE_DIR
     curl -# -L $BIN_URL | tar xJ -C $CACHE_DIR
-    mv $CACHE_DIR/postgrest $CACHE_DIR/$BIN
+    if ! ver20; then
+      mv $CACHE_DIR/postgrest $CACHE_DIR/$BIN
+    fi
   else
     echo "-----> Could not find prebuilt $BIN"
     exit 1


### PR DESCRIPTION
**Issue:** the `POSTGREST_VER` environment variable is only applied to non-cached builds. Updating the variable _does not_ update the `postgrest` binary version. Currently, to upgrade PostgREST on Heroku you must [install a plugin and clear the build cache](https://help.heroku.com/18PI5RSY/how-do-i-clear-the-build-cache).

In this diff, I changed the caching code to always track the version tag. `ver20` seems to be a special case that already used this behavior: now all other versions are "promoted" to working the same way.

One downside with this approach is that old binary versions are maintained in the cache. I still think this is a nicer default, but just thought I would raise the point.

Thanks!