### PR TITLE
Update Heroku buildpack support from 0.5.0.0 to v7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,35 @@ We recommend spinning up a Postgres database with
 2.  Create a new Heroku app using this Heroku buildpack:
 
     ```bash
-    heroku apps:create --buildpack https://github.com/formdeploy/postgrest-heroku.git
+    heroku apps:create ${YOUR_APP_NAME} --buildpack https://github.com/formdeploy/postgrest-heroku.git
+    heroku git:remote -a ${YOUR_APP_NAME}
     ```
+
+3.  Create an account on ElephantSQL, and [create an API
+    key](https://customer.elephantsql.com/apikeys) to use the [ElephantSQL
+    customer API](https://docs.elephantsql.com/). Run the following `curl`
+    command in order to create a PostgreSQL instance on ElephantSQL:
+
+    ```bash
+    curl \
+        -u :${YOUR_API_KEY} \
+        -d "name=${YOUR_DB_NAME}&plan=turtle&region=amazon-web-services::us-east-1" \
+        https://customer.elephantsql.com/api/instances
+    ```
+
+    Get the PostgreSQL DB URI from the ElephantSQL console and set as env
+    variable `DB_URI`. Make sure the URI field is expanded before copying.
+
+    Take the database name (with assumed backing role of identical name) and set
+    as env variable `DB_ANON_ROLE`.
 
 3.  Set Heroku environment variables:
 
     ```bash
     heroku config:set POSTGREST_VER=7.0.1
-    heroku config:set DB_URI=postgres://postgrest_test:postgrest111@postgrest-test.crbxuv1p3j1c.us-west-1.rds.amazonaws.com/postgrest_test
+    heroku config:set DB_URI=${DB_URI}
     heroku config:set DB_SCHEMA=public
-    heroku config:set DB_ANON_ROLE=postgrest_test
+    heroku config:set DB_ANON_ROLE=${DB_ANON_ROLE}
     heroku config:set DB_POOL=60
     ```
 
@@ -44,6 +63,8 @@ We recommend spinning up a Postgres database with
     ```bash
     git push heroku master
     ```
+
+Your Heroku app should be live at `${YOUR_APP_NAME}.herokuapp.com`.
 
 ### Configuring PostgreSQL
 

--- a/README.md
+++ b/README.md
@@ -2,40 +2,54 @@
 
 The best way to build an API, now for Heroku.
 
-Make a git repo with anything in it. The repo is just a pretext to push to
-Heroku.
+Updated for PostgREST v7.0.1.
 
-Note that **the free tier Heroku PostgreSQL addon will not work** because it
-does not support having multiple database roles. **Heroku Postgres** paid tiers
-do support multiple database roles though you'll have to create them through
+NOTE: **The free tier Heroku PostgreSQL addon will not work** because it does
+not support having multiple database roles. **Heroku Postgres** paid tiers do
+support multiple database roles, though you'll have to create them through
 [Heroku Postgres
 Credentials](https://devcenter.heroku.com/articles/heroku-postgresql-credentials).
 
-We recommend spinning up a Postgres database with [Amazon
-RDS](https://aws.amazon.com/rds/). Make sure you create it in the **Virginia
-region** because that's where Heroku's dynos are and it will decrease latency
-between the server and db.
+We recommend spinning up a Postgres database with
+[ElephantSQL](https://www.elephantsql.com/) for free tier usage.
 
-Next install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
-and run these commands.
+### To Deploy PostgREST on Heroku
 
-```bash
-# first set up a new app
-heroku apps:create --buildpack https://github.com/formdeploy/postgrest-heroku.git
+1.  Log into Heroku using the [Heroku
+    CLI](https://devcenter.heroku.com/articles/heroku-cli):
 
-# now fill in the values specific to your database
-heroku config:set POSTGREST_VER=7.0.1
-heroku config:set DB_URI=postgres://postgrest_test:postgrest111@postgrest-test.crbxuv1p3j1c.us-west-1.rds.amazonaws.com/postgrest_test
-heroku config:set DB_SCHEMA=public
-heroku config:set DB_ANON_ROLE=postgrest_test
-heroku config:set DB_POOL=60
+    ```bash
+    # If you have multiple Heroku accounts, use flag '--interactive' to switch between them
+    heroku login --interactive
+    ```
 
-git push heroku master
-```
+2.  Create a new Heroku app using this Heroku buildpack:
 
-To determine the best value for `DB_POOL` ask the database by
-running this SQL:
+    ```bash
+    heroku apps:create --buildpack https://github.com/formdeploy/postgrest-heroku.git
+    ```
 
-```SQL
-show max_connections;
-```
+3.  Set Heroku environment variables:
+
+    ```bash
+    heroku config:set POSTGREST_VER=7.0.1
+    heroku config:set DB_URI=postgres://postgrest_test:postgrest111@postgrest-test.crbxuv1p3j1c.us-west-1.rds.amazonaws.com/postgrest_test
+    heroku config:set DB_SCHEMA=public
+    heroku config:set DB_ANON_ROLE=postgrest_test
+    heroku config:set DB_POOL=60
+    ```
+
+4.  Create the Heroku dyno:
+
+    ```bash
+    git push heroku master
+    ```
+
+### Configuring PostgreSQL
+
+-   To determine the best value for PostgREST environment variable `DB_POOL`,
+    ask the database by running this SQL:
+
+    ```sql
+    show max_connections;
+    ```

--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 The best way to build an API, now for Heroku.
 
-Make a git repo with anything in it. The repo is just a pretext to
-push to Heroku.
+Make a git repo with anything in it. The repo is just a pretext to push to
+Heroku.
 
 Note that **the free tier Heroku PostgreSQL addon will not work** because it
-does not support having multiple database roles. **Heroku Postgres** paid tiers do support multiple
-database roles though you'll have to create them through [Heroku Postgres Credentials](https://devcenter.heroku.com/articles/heroku-postgresql-credentials).
+does not support having multiple database roles. **Heroku Postgres** paid tiers
+do support multiple database roles though you'll have to create them through
+[Heroku Postgres
+Credentials](https://devcenter.heroku.com/articles/heroku-postgresql-credentials).
 
 We recommend spinning up a Postgres database with [Amazon
-RDS](https://aws.amazon.com/rds/). Make sure you create it in
-the **Virginia region** because that's where Heroku's dynos are
-and it will decrease latency between the server and db.
+RDS](https://aws.amazon.com/rds/). Make sure you create it in the **Virginia
+region** because that's where Heroku's dynos are and it will decrease latency
+between the server and db.
 
-Next install the [Heroku Toolbelt](https://toolbelt.heroku.com/)
+Next install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 and run these commands.
 
 ```bash
 # first set up a new app
-heroku apps:create --buildpack https://github.com/PostgREST/postgrest-heroku.git
+heroku apps:create --buildpack https://github.com/formdeploy/postgrest-heroku.git
 
 # now fill in the values specific to your database
-heroku config:set POSTGREST_VER=0.5.0.0
+heroku config:set POSTGREST_VER=7.0.1
 heroku config:set DB_URI=postgres://postgrest_test:postgrest111@postgrest-test.crbxuv1p3j1c.us-west-1.rds.amazonaws.com/postgrest_test
 heroku config:set DB_SCHEMA=public
 heroku config:set DB_ANON_ROLE=postgrest_test

--- a/bin/compile
+++ b/bin/compile
@@ -77,7 +77,7 @@ else
 fi
 
 if [ ! -e $CACHE_DIR/$BIN ]; then
-  BIN_URL="https://github.com/PostgREST/postgrest/releases/download/v${POSTGREST_VER}/postgrest-${RELEASE_VER}-ubuntu.tar.xz"
+  BIN_URL="https://github.com/PostgREST/postgrest/releases/download/v${POSTGREST_VER}/postgrest-${RELEASE_VER}-linux-x64-static.tar.xz"
   if curl --output /dev/null --silent --head --fail $BIN_URL; then
     echo "-----> Downloading and caching PostgREST $POSTGREST_VER binary"
     mkdir -p $CACHE_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -10,20 +10,10 @@ CACHE_DIR="$2"
 ENV_DIR="$3"
 BP_DIR=`cd $(dirname $0); cd ..; pwd`
 
-POSTGREST_VER=${POSTGREST_VER:-0.5.0.0}
-CLEAR_CACHE=${CLEAR_CACHE:-0}
+POSTGREST_VER=${POSTGREST_VER:-7.0.1}
+RELEASE_VER="v${POSTGREST_VER}"
 
-ver20() {
-  [[ $POSTGREST_VER == "0.2"* ]]
-}
-ver30() {
-  [[ $POSTGREST_VER == "0.3"* ]]
-}
-ver40to42() {
-  [[ $POSTGREST_VER == "0.4.0.0" ]] || \
-  [[ $POSTGREST_VER == "0.4.1.0" ]] || \
-  [[ $POSTGREST_VER == "0.4.2.0" ]]
-}
+CLEAR_CACHE=${CLEAR_CACHE:-0}
 
 export_env_dir() {
   local env_dir=${1:-$ENV_DIR}
@@ -48,33 +38,9 @@ if [[ $CLEAR_CACHE -eq 1 ]] ; then
   rm -fr $CACHE_DIR/
 fi
 
-############# Library files ###############################
-
-if [ ! -e $CACHE_DIR/ghc-libs ]; then
-  LIBS_URL="https://github.com/PostgREST/postgrest-heroku/releases/download/v0.4.4.0/ghc-libs.tar.xz"
-  if curl --output /dev/null --silent --head --fail $LIBS_URL; then
-    echo "-----> Downloading and caching libraries for PostgREST"
-    mkdir -p $CACHE_DIR
-    curl -# -L $LIBS_URL | tar xJ -C $CACHE_DIR
-    cp -R $CACHE_DIR/ghc-libs $BUILD_DIR
-  else
-    echo "-----> Could not find prebuilt libraries"
-    exit 1
-  fi
-else
-  echo "-----> Restoring cached libraries"
-  cp -R $CACHE_DIR/ghc-libs $BUILD_DIR
-fi
-
 ############# PostgREST binary ################################
 
 BIN="postgrest-${POSTGREST_VER}"
-
-if ver20 || ver30 || ver40to42; then
-  RELEASE_VER="${POSTGREST_VER}"
-else
-  RELEASE_VER="v${POSTGREST_VER}"
-fi
 
 if [ ! -e $CACHE_DIR/$BIN ]; then
   BIN_URL="https://github.com/PostgREST/postgrest/releases/download/v${POSTGREST_VER}/postgrest-${RELEASE_VER}-linux-x64-static.tar.xz"


### PR DESCRIPTION
Hello,

I had wanted to use the latest version of PostgREST, but deploying from Heroku had a max supported version number of 0.5.0.0. I saw in the documentation Heroku was the preferred deployment platform, so I upgraded the Heroku buildpack to support v7.0.1.

Primary issue is changing the ubuntu.tar.gz to linux-x64-static.tar.gz, in addition I also removed the cache libs because it supported 0.4.x only, and updated the documentation.

Thanks
Ying