### PR TITLE
Handle suffix from linux static tar above version 7

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,6 +28,10 @@ ver_below_6() {
   [[ $POSTGREST_VER == "0."* ]] || \
   [[ $POSTGREST_VER == "5."* ]]
 }
+ver_below_8() {
+  [[ $POSTGREST_VER == "0."* ]] || \
+  [[ $POSTGREST_VER == "7."* ]]
+}
 
 export_env_dir() {
   local env_dir=${1:-$ENV_DIR}
@@ -82,8 +86,10 @@ fi
 
 if ver_below_6; then
   FILE_SUFFIX="ubuntu"
-else
+else if ver_below_8; then
   FILE_SUFFIX="linux-x64-static"
+else
+  FILE_SUFFIX="linux-static-x64"
 fi
 
 if [ ! -e $CACHE_DIR/$BIN ]; then


### PR DESCRIPTION
Try to handle name nomenclature between version 7 and above

linux-x64-static

and 

linux-static-x64
