### PR TITLE
Add the openapi-mode config

### DIFF
--- a/env-to-config
+++ b/env-to-config
@@ -14,6 +14,7 @@ config_settings=(
   server-port
   server-unix-socket
   server-unix-socket-mode
+  openapi-mode
   openapi-server-proxy-uri
   server-proxy-uri
   jwt-secret


### PR DESCRIPTION
This was added in v8.0.0 and I would like to use it in Heroku where I have v10 currently running.