### PR TITLE
updated buildpack URL after merge with PR #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Credentials](https://devcenter.heroku.com/articles/heroku-postgresql-credentials
     cd ${YOUR_APP_NAME}
     git init .
 
-    heroku apps:create ${YOUR_APP_NAME} --buildpack https://github.com/abernicchia-heroku/postgrest-heroku.git
+    heroku apps:create ${YOUR_APP_NAME} --buildpack https://github.com/PostgREST/postgrest-heroku.git
     heroku git:remote -a ${YOUR_APP_NAME}
     ```
 


### PR DESCRIPTION
Now it's also necessary to publish the buildpack so the Heroku Elements page (basically README.md) for the buildpack (https://elements.heroku.com/buildpacks/postgrest/postgrest-heroku) is aligned with GitHub too - see https://devcenter.heroku.com/articles/buildpack-registry#publishing-a-buildpack-version